### PR TITLE
Fixed unable to build examples with installed DBus

### DIFF
--- a/CommonAPI-Examples/E01HelloWorld/CMakeLists.txt
+++ b/CommonAPI-Examples/E01HelloWorld/CMakeLists.txt
@@ -128,6 +128,7 @@ link_directories(
     ${COMMONAPI_LIBDIR}
     ${COMMONAPI_DBUS_LIBDIR}
     ${COMMONAPI_SOMEIP_CMAKE_DIR}/build
+    ${DBus_LIBRARY_DIRS}
     ${Boost_LIBRARY_DIR}
 )
 else()

--- a/CommonAPI-Examples/E02Attributes/CMakeLists.txt
+++ b/CommonAPI-Examples/E02Attributes/CMakeLists.txt
@@ -128,6 +128,7 @@ link_directories(
     ${COMMONAPI_LIBDIR}
     ${COMMONAPI_DBUS_LIBDIR}
     ${COMMONAPI_SOMEIP_CMAKE_DIR}/build
+    ${DBus_LIBRARY_DIRS}
     ${Boost_LIBRARY_DIR}
 )
 else()

--- a/CommonAPI-Examples/E03Methods/CMakeLists.txt
+++ b/CommonAPI-Examples/E03Methods/CMakeLists.txt
@@ -130,6 +130,7 @@ link_directories(
     ${COMMONAPI_LIBDIR}
     ${COMMONAPI_DBUS_LIBDIR}
     ${COMMONAPI_SOMEIP_CMAKE_DIR}/build
+    ${DBus_LIBRARY_DIRS}
     ${Boost_LIBRARY_DIR}
 )
 else()

--- a/CommonAPI-Examples/E04PhoneBook/CMakeLists.txt
+++ b/CommonAPI-Examples/E04PhoneBook/CMakeLists.txt
@@ -131,6 +131,7 @@ link_directories(
     ${COMMONAPI_LIBDIR}
     ${COMMONAPI_DBUS_LIBDIR}
     ${COMMONAPI_SOMEIP_CMAKE_DIR}/build
+    ${DBus_LIBRARY_DIRS}
     ${Boost_LIBRARY_DIR}
 )
 else()

--- a/CommonAPI-Examples/E05Manager/CMakeLists.txt
+++ b/CommonAPI-Examples/E05Manager/CMakeLists.txt
@@ -128,6 +128,7 @@ link_directories(
     ${COMMONAPI_LIBDIR}
     ${COMMONAPI_DBUS_LIBDIR}
     ${COMMONAPI_SOMEIP_CMAKE_DIR}/build
+    ${DBus_LIBRARY_DIRS}
     ${Boost_LIBRARY_DIR}
 )
 else()

--- a/CommonAPI-Examples/E06Unions/CMakeLists.txt
+++ b/CommonAPI-Examples/E06Unions/CMakeLists.txt
@@ -131,6 +131,7 @@ link_directories(
     ${COMMONAPI_LIBDIR}
     ${COMMONAPI_DBUS_LIBDIR}
     ${COMMONAPI_SOMEIP_CMAKE_DIR}/build
+    ${DBus_LIBRARY_DIRS}
     ${Boost_LIBRARY_DIR}
 )
 else()

--- a/CommonAPI-Examples/E07Mainloop/CMakeLists.txt
+++ b/CommonAPI-Examples/E07Mainloop/CMakeLists.txt
@@ -160,6 +160,7 @@ link_directories(
     ${COMMONAPI_LIBDIR}
     ${COMMONAPI_DBUS_LIBDIR}
     ${COMMONAPI_SOMEIP_CMAKE_DIR}/build
+    ${DBus_LIBRARY_DIRS}
     ${Boost_LIBRARY_DIR}
 )
 else()


### PR DESCRIPTION
When building commonAPI examples on an environment where the DBus libraries are not in a default location (for example cross-compiling without a virtual root), the DBus library directory could not be passed to the build script. This enables command-line customization of the DBus library directory.