### PR TITLE
Removed reserved _ from template name

### DIFF
--- a/docx/CommonAPICppSpecification
+++ b/docx/CommonAPICppSpecification
@@ -893,8 +893,8 @@ API for getting and setting configuration properties at runtime.
 
 [source,{cppstr}]
 ----
-template< template<typename ...> class _ProxyClass, typename ... _AttributeExtensions >
-std::shared_ptr< _ProxyClass<_AttributeExtensions...> > buildProxy(
+template< template<typename ...> class _ProxyClass, typename ... TAttributeExtensions >
+std::shared_ptr< _ProxyClass<TAttributeExtensions...> > buildProxy(
 	const std::string &_domain,
     const std::string &_instance,
     const ConnectionId_t &_connectionId = DEFAULT_CONNECTION_ID) {
@@ -909,8 +909,8 @@ The _buildProxy_ method is a factory method for instantiating a proxy class for 
 
 [source,{cppstr}]
 ----
-template<template<typename ...> class _ProxyClass, typename ... _AttributeExtensions >
-std::shared_ptr< _ProxyClass<_AttributeExtensions...> > buildProxy(
+template<template<typename ...> class _ProxyClass, typename ... TAttributeExtensions >
+std::shared_ptr< _ProxyClass<TAttributeExtensions...> > buildProxy(
 	const std::string &_domain,
     const std::string &_instance,
     std::shared_ptr<MainLoopContext> _context) {

--- a/org.genivi.commonapi.core/src/org/genivi/commonapi/core/generator/FInterfaceProxyGenerator.xtend
+++ b/org.genivi.commonapi.core/src/org/genivi/commonapi/core/generator/FInterfaceProxyGenerator.xtend
@@ -159,12 +159,12 @@ class FInterfaceProxyGenerator {
         «fInterface.generateVersionNamespaceBegin»
         «fInterface.model.generateNamespaceBeginDeclaration»
 
-        template <typename ... _AttributeExtensions>
+        template <typename ... TAttributeExtensions>
         class «fInterface.proxyClassName»
             : virtual public «fInterface.elementName»,
               virtual public «fInterface.proxyBaseClassName»,«IF fInterface.base !== null»
-              public «fInterface.base.getTypeCollectionName(fInterface)»Proxy<_AttributeExtensions...>,«ENDIF»
-              virtual public _AttributeExtensions... {
+              public «fInterface.base.getTypeCollectionName(fInterface)»Proxy<TAttributeExtensions...>,«ENDIF»
+              virtual public TAttributeExtensions... {
         public:
             «fInterface.proxyClassName»(std::shared_ptr<CommonAPI::Proxy> delegate);
             ~«fInterface.proxyClassName»();
@@ -276,25 +276,25 @@ class FInterfaceProxyGenerator {
         //
         // «fInterface.proxyClassName» Implementation
         //
-        template <typename ... _AttributeExtensions>
-        «fInterface.proxyClassName»<_AttributeExtensions...>::«fInterface.proxyClassName»(std::shared_ptr<CommonAPI::Proxy> delegate):
+        template <typename ... TAttributeExtensions>
+        «fInterface.proxyClassName»<TAttributeExtensions...>::«fInterface.proxyClassName»(std::shared_ptr<CommonAPI::Proxy> delegate):
                 «IF fInterface.base !== null»
-                «fInterface.base.getFullName()»Proxy<_AttributeExtensions...>(delegate),
+                «fInterface.base.getFullName()»Proxy<TAttributeExtensions...>(delegate),
                 «ENDIF»
-                _AttributeExtensions(*(std::dynamic_pointer_cast< «fInterface.proxyBaseClassName»>(delegate)))...,
+                TAttributeExtensions(*(std::dynamic_pointer_cast< «fInterface.proxyBaseClassName»>(delegate)))...,
                 delegate_(std::dynamic_pointer_cast< «fInterface.proxyBaseClassName»>(delegate)) {
         }
 
-        template <typename ... _AttributeExtensions>
-        «fInterface.proxyClassName»<_AttributeExtensions...>::~«fInterface.proxyClassName»() {
+        template <typename ... TAttributeExtensions>
+        «fInterface.proxyClassName»<TAttributeExtensions...>::~«fInterface.proxyClassName»() {
         }
 
         «FOR itsElement : fInterface.elements»
             «IF itsElement instanceof FMethod»
                 «FTypeGenerator::generateComments(itsElement, false)»
                 «IF generateSyncCalls || itsElement.isFireAndForget»
-                template <typename ... _AttributeExtensions>
-                «itsElement.generateDefinitionWithin(fInterface.proxyClassName + '<_AttributeExtensions...>', false)» {
+                template <typename ... TAttributeExtensions>
+                «itsElement.generateDefinitionWithin(fInterface.proxyClassName + '<TAttributeExtensions...>', false)» {
                     «FOR arg : itsElement.inArgs»
                         «IF !arg.array && arg.getType.supportsValidation»
                             if (!_«arg.elementName».validate()) {
@@ -308,8 +308,8 @@ class FInterfaceProxyGenerator {
                 «ENDIF»
                 «IF !itsElement.isFireAndForget»
 
-                    template <typename ... _AttributeExtensions>
-                    «itsElement.generateAsyncDefinitionWithin(fInterface.proxyClassName + '<_AttributeExtensions...>', false)» {
+                    template <typename ... TAttributeExtensions>
+                    «itsElement.generateAsyncDefinitionWithin(fInterface.proxyClassName + '<TAttributeExtensions...>', false)» {
                         «FOR arg : itsElement.inArgs»
                             «IF !arg.array && arg.getType.supportsValidation»
                                 if (!_«arg.elementName».validate()) {
@@ -328,40 +328,40 @@ class FInterfaceProxyGenerator {
             «ENDIF»
         «ENDFOR»
 
-        template <typename ... _AttributeExtensions>
-        const CommonAPI::Address &«fInterface.proxyClassName»<_AttributeExtensions...>::getAddress() const {
+        template <typename ... TAttributeExtensions>
+        const CommonAPI::Address &«fInterface.proxyClassName»<TAttributeExtensions...>::getAddress() const {
             return delegate_->getAddress();
         }
 
-        template <typename ... _AttributeExtensions>
-        bool «fInterface.proxyClassName»<_AttributeExtensions...>::isAvailable() const {
+        template <typename ... TAttributeExtensions>
+        bool «fInterface.proxyClassName»<TAttributeExtensions...>::isAvailable() const {
             return delegate_->isAvailable();
         }
 
-        template <typename ... _AttributeExtensions>
-        bool «fInterface.proxyClassName»<_AttributeExtensions...>::isAvailableBlocking() const {
+        template <typename ... TAttributeExtensions>
+        bool «fInterface.proxyClassName»<TAttributeExtensions...>::isAvailableBlocking() const {
             return delegate_->isAvailableBlocking();
         }
 
-        template <typename ... _AttributeExtensions>
-        CommonAPI::ProxyStatusEvent& «fInterface.proxyClassName»<_AttributeExtensions...>::getProxyStatusEvent() {
+        template <typename ... TAttributeExtensions>
+        CommonAPI::ProxyStatusEvent& «fInterface.proxyClassName»<TAttributeExtensions...>::getProxyStatusEvent() {
             return delegate_->getProxyStatusEvent();
         }
 
-        template <typename ... _AttributeExtensions>
-        CommonAPI::InterfaceVersionAttribute& «fInterface.proxyClassName»<_AttributeExtensions...>::getInterfaceVersionAttribute() {
+        template <typename ... TAttributeExtensions>
+        CommonAPI::InterfaceVersionAttribute& «fInterface.proxyClassName»<TAttributeExtensions...>::getInterfaceVersionAttribute() {
             return delegate_->getInterfaceVersionAttribute();
         }
 
         «FOR managed : fInterface.managedInterfaces»
-            template <typename ... _AttributeExtensions>
-            CommonAPI::ProxyManager& «fInterface.proxyClassName»<_AttributeExtensions...>::«managed.proxyManagerGetterName»() {
+            template <typename ... TAttributeExtensions>
+            CommonAPI::ProxyManager& «fInterface.proxyClassName»<TAttributeExtensions...>::«managed.proxyManagerGetterName»() {
                 return delegate_->«managed.proxyManagerGetterName»();
             }
         «ENDFOR»
 
-        template <typename ... _AttributeExtensions>
-        std::future<void> «fInterface.proxyClassName»<_AttributeExtensions...>::getCompletionFuture() {
+        template <typename ... TAttributeExtensions>
+        std::future<void> «fInterface.proxyClassName»<TAttributeExtensions...>::getCompletionFuture() {
             return delegate_->getCompletionFuture();
         }
 


### PR DESCRIPTION
The C++ templates [here](https://github.com/COVESA/capicxx-core-tools/blob/1e6e696fcf3a0dcf470e0d3a761cffd85321609f/org.genivi.commonapi.core/src/org/genivi/commonapi/core/generator/FInterfaceProxyGenerator.xtend#L162) use the symbol `_AttributeExtensions` which is reserved.

https://github.com/COVESA/capicxx-core-tools/blob/1e6e696fcf3a0dcf470e0d3a761cffd85321609f/org.genivi.commonapi.core/src/org/genivi/commonapi/core/generator/FInterfaceProxyGenerator.xtend#L162-L163

> In addition to the names documented in this manual, reserved names include all external identifiers (global functions and variables) that begin with an underscore (‘_’) and all identifiers regardless of use that begin with either two underscores or **an underscore followed by a capital letter are reserved names**. This is so that the library and header files can define functions, variables, and macros for internal purposes without risk of conflict with names in user programs. 

[Reserved Names](https://www.gnu.org/savannah-checkouts/gnu/libc/manual/html_node/Reserved-Names.html)

I haven't encountered any problems with this, but it does introduce undefined behaviour which concerns me.

This addressed https://github.com/COVESA/capicxx-core-tools/issues/42.  I haven't tested this PR as I have build issues with maven.